### PR TITLE
Update git-lfs to 3.4.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,39 @@
+## Building or updating
+
+```bash
+git clone https://github.com/git-lfs/git-lfs.git && cd git-lfs
+git checkout $tag
+go mod vendor
+```
+or uncomment `build-args` in manifest and run
+
+```bash
+flatpak-builder build --force-clean --keep-build-dirs com.visualstudio.code.tool.git-lfs.yml
+```
+
+Copy `vendor/modules.txt` (`.flatpak-builder/build/git-lfs/vendor/modules.txt`) and replace file in manifest root.
+
+```bash
+flatpak-go-vendor-generator.py modules.txt
+```
+
+Copy and paste to `vendor-sources.json` in manifest root.
+
+The following sources need to manually switched from `git` to zip files from `https://proxy.golang.org/`:
+
+```
+jcmturner/aescts/v2
+jcmturner/dnsutils/v2
+jcmturner/gofork
+jcmturner/goidentity/v6
+jcmturner/gokrb5/v8
+jcmturner/rpc/v2
+```
+
+Run this in the source directory of git-lfs to get `https://proxy.golang.org/` urls
+
+```bash
+go mod download -json | grep '"Zip"' | cut -d '"' -f 4 | sed -E 's|.*?download/|https://proxy.golang.org/|'|while read m; do echo -e "- type: archive\n  url: $m\n  dest: ENTER\n  strip-components: ENTER\n  sha256: $(curl -fsS "$m" | sha256sum -b | cut -d ' ' -f 1)\n"; done
+```
+
+replace `dest` of the module with `dest` produced from `flatpak-go-vendor-generator.py` and adjust `strip-components` accordingly.

--- a/com.visualstudio.code.tool.git-lfs.metainfo.xml
+++ b/com.visualstudio.code.tool.git-lfs.metainfo.xml
@@ -7,6 +7,7 @@
   <summary>Git extension for versioning large files</summary>
   <url type="homepage">https://git-lfs.github.com/</url>
   <releases>
+    <release version="3.4.1" date="2023-12-22"/>
     <release version="3.3.0" date="2023-02-14"/>
   </releases>
 </component>

--- a/com.visualstudio.code.tool.git-lfs.yml
+++ b/com.visualstudio.code.tool.git-lfs.yml
@@ -15,36 +15,36 @@ modules:
 
     build-options:
       append-path: /usr/lib/sdk/golang/bin
-      # uncomment when generating vendor-sources.json
-      # build-args:
-      #   - --share=network
-      env:
-        GO111MODULE: on
-        GOFLAGS: -mod=vendor
+#      uncomment when generating vendor-sources.json
+#      build-args:
+#         - --share=network
 
     build-commands:
-      # - go mod vendor # uncomment when generating vendor-sources.json
+#        uncomment when generating vendor-sources.json
+#      - go mod download -json | grep '"Zip"' | cut -d '"' -f 4 | sed -E 's|.*?download/|https://proxy.golang.org/|'|while read m; do echo -e "- type: archive\n  url: $m\n  dest: ENTER\n  strip-components: ENTER\n  sha256: $(curl -fsS "$m" | sha256sum -b | cut -d ' ' -f 1)\n"; done
       - go build
       - install -Dm755 -t ${FLATPAK_DEST}/bin git-lfs
 
     sources:
+      - vendor-sources.json
       - type: git
         url: https://github.com/git-lfs/git-lfs.git
-        tag: v3.3.0
-        commit: 77deabdf9a18f8a07ecfd3e0f4aa572ffbbab8d4
-
+        tag: v3.4.1
+        commit: 0898dcbc0a9dd281701c4ef6603b50d46be4dabc
         x-checker-data:
           type: git
           tag-pattern: ^v([\d.]+)$
-
-      - vendor-sources.json
+# Comment when generating modules.txt
+      - type: file
+        path: modules.txt
+        dest: vendor
 
   - name: bundle-setup
     buildsystem: simple
-
     build-commands:
       - install -Dm644 ${FLATPAK_ID}.metainfo.xml -t ${FLATPAK_DEST}/share/metainfo
-      - appstream-compose --basename=${FLATPAK_ID} --prefix=${FLATPAK_DEST} --origin=flatpak ${FLATPAK_ID}
+      - appstream-compose --basename=${FLATPAK_ID} --prefix=${FLATPAK_DEST} --origin=flatpak
+        ${FLATPAK_ID}
 
     sources:
       - type: file

--- a/modules.txt
+++ b/modules.txt
@@ -1,0 +1,160 @@
+# github.com/alexbrainman/sspi v0.0.0-20210105120005-909beea2cc74
+## explicit; go 1.13
+github.com/alexbrainman/sspi
+github.com/alexbrainman/sspi/internal/common
+github.com/alexbrainman/sspi/negotiate
+# github.com/avast/retry-go v2.4.2+incompatible
+## explicit
+github.com/avast/retry-go
+# github.com/davecgh/go-spew v1.1.1
+## explicit
+github.com/davecgh/go-spew/spew
+# github.com/dpotapov/go-spnego v0.0.0-20210315154721-298b63a54430
+## explicit; go 1.12
+github.com/dpotapov/go-spnego
+# github.com/git-lfs/gitobj/v2 v2.1.1
+## explicit; go 1.11
+github.com/git-lfs/gitobj/v2
+github.com/git-lfs/gitobj/v2/errors
+github.com/git-lfs/gitobj/v2/pack
+github.com/git-lfs/gitobj/v2/storage
+# github.com/git-lfs/go-netrc v0.0.0-20210914205454-f0c862dd687a
+## explicit
+github.com/git-lfs/go-netrc/netrc
+# github.com/git-lfs/pktline v0.0.0-20210330133718-06e9096e2825
+## explicit; go 1.12
+github.com/git-lfs/pktline
+# github.com/git-lfs/wildmatch/v2 v2.0.1
+## explicit; go 1.15
+github.com/git-lfs/wildmatch/v2
+# github.com/hashicorp/go-uuid v1.0.2
+## explicit
+github.com/hashicorp/go-uuid
+# github.com/inconshreveable/mousetrap v1.0.1
+## explicit; go 1.18
+github.com/inconshreveable/mousetrap
+# github.com/jcmturner/aescts/v2 v2.0.0
+## explicit; go 1.13
+github.com/jcmturner/aescts/v2
+# github.com/jcmturner/dnsutils/v2 v2.0.0
+## explicit; go 1.13
+github.com/jcmturner/dnsutils/v2
+# github.com/jcmturner/gofork v1.0.0
+## explicit
+github.com/jcmturner/gofork/encoding/asn1
+github.com/jcmturner/gofork/x/crypto/pbkdf2
+# github.com/jcmturner/goidentity/v6 v6.0.1
+## explicit; go 1.13
+github.com/jcmturner/goidentity/v6
+# github.com/jcmturner/gokrb5/v8 v8.4.2
+## explicit; go 1.14
+github.com/jcmturner/gokrb5/v8/asn1tools
+github.com/jcmturner/gokrb5/v8/client
+github.com/jcmturner/gokrb5/v8/config
+github.com/jcmturner/gokrb5/v8/credentials
+github.com/jcmturner/gokrb5/v8/crypto
+github.com/jcmturner/gokrb5/v8/crypto/common
+github.com/jcmturner/gokrb5/v8/crypto/etype
+github.com/jcmturner/gokrb5/v8/crypto/rfc3961
+github.com/jcmturner/gokrb5/v8/crypto/rfc3962
+github.com/jcmturner/gokrb5/v8/crypto/rfc4757
+github.com/jcmturner/gokrb5/v8/crypto/rfc8009
+github.com/jcmturner/gokrb5/v8/gssapi
+github.com/jcmturner/gokrb5/v8/iana
+github.com/jcmturner/gokrb5/v8/iana/addrtype
+github.com/jcmturner/gokrb5/v8/iana/adtype
+github.com/jcmturner/gokrb5/v8/iana/asnAppTag
+github.com/jcmturner/gokrb5/v8/iana/chksumtype
+github.com/jcmturner/gokrb5/v8/iana/errorcode
+github.com/jcmturner/gokrb5/v8/iana/etypeID
+github.com/jcmturner/gokrb5/v8/iana/flags
+github.com/jcmturner/gokrb5/v8/iana/keyusage
+github.com/jcmturner/gokrb5/v8/iana/msgtype
+github.com/jcmturner/gokrb5/v8/iana/nametype
+github.com/jcmturner/gokrb5/v8/iana/patype
+github.com/jcmturner/gokrb5/v8/kadmin
+github.com/jcmturner/gokrb5/v8/keytab
+github.com/jcmturner/gokrb5/v8/krberror
+github.com/jcmturner/gokrb5/v8/messages
+github.com/jcmturner/gokrb5/v8/pac
+github.com/jcmturner/gokrb5/v8/service
+github.com/jcmturner/gokrb5/v8/spnego
+github.com/jcmturner/gokrb5/v8/types
+# github.com/jcmturner/rpc/v2 v2.0.3
+## explicit; go 1.13
+github.com/jcmturner/rpc/v2/mstypes
+github.com/jcmturner/rpc/v2/ndr
+# github.com/leonelquinteros/gotext v1.5.0
+## explicit; go 1.13
+github.com/leonelquinteros/gotext
+github.com/leonelquinteros/gotext/plurals
+# github.com/mattn/go-isatty v0.0.4
+## explicit
+github.com/mattn/go-isatty
+# github.com/olekukonko/ts v0.0.0-20171002115256-78ecb04241c0
+## explicit
+github.com/olekukonko/ts
+# github.com/pkg/errors v0.0.0-20170505043639-c605e284fe17
+## explicit
+github.com/pkg/errors
+# github.com/pmezard/go-difflib v1.0.0
+## explicit
+github.com/pmezard/go-difflib/difflib
+# github.com/rubyist/tracerx v0.0.0-20170927163412-787959303086
+## explicit
+github.com/rubyist/tracerx
+# github.com/spf13/cobra v1.6.0
+## explicit; go 1.15
+github.com/spf13/cobra
+# github.com/spf13/pflag v1.0.5
+## explicit; go 1.12
+github.com/spf13/pflag
+# github.com/ssgelm/cookiejarparser v1.0.1
+## explicit; go 1.13
+github.com/ssgelm/cookiejarparser
+# github.com/stretchr/testify v1.6.1
+## explicit; go 1.13
+github.com/stretchr/testify/assert
+github.com/stretchr/testify/require
+# github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f
+## explicit
+github.com/xeipuuv/gojsonpointer
+# github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415
+## explicit
+github.com/xeipuuv/gojsonreference
+# github.com/xeipuuv/gojsonschema v0.0.0-20170210233622-6b67b3fab74d
+## explicit
+github.com/xeipuuv/gojsonschema
+# golang.org/x/crypto v0.0.0-20220411220226-7b82a4e95df4
+## explicit; go 1.17
+golang.org/x/crypto/md4
+golang.org/x/crypto/pbkdf2
+# golang.org/x/net v0.7.0
+## explicit; go 1.17
+golang.org/x/net/http/httpguts
+golang.org/x/net/http/httpproxy
+golang.org/x/net/http2
+golang.org/x/net/http2/hpack
+golang.org/x/net/idna
+golang.org/x/net/publicsuffix
+# golang.org/x/sync v0.1.0
+## explicit
+golang.org/x/sync/semaphore
+# golang.org/x/sys v0.5.0
+## explicit; go 1.17
+golang.org/x/sys/internal/unsafeheader
+golang.org/x/sys/unix
+golang.org/x/sys/windows
+# golang.org/x/text v0.7.0
+## explicit; go 1.17
+golang.org/x/text/internal/language
+golang.org/x/text/internal/language/compact
+golang.org/x/text/internal/tag
+golang.org/x/text/language
+golang.org/x/text/secure/bidirule
+golang.org/x/text/transform
+golang.org/x/text/unicode/bidi
+golang.org/x/text/unicode/norm
+# gopkg.in/yaml.v3 v3.0.1
+## explicit
+gopkg.in/yaml.v3

--- a/vendor-sources.json
+++ b/vendor-sources.json
@@ -56,44 +56,50 @@
     {
         "type": "git",
         "url": "https://github.com/inconshreveable/mousetrap.git",
-        "tag": "v1.0.0",
+        "tag": "v1.0.1",
         "dest": "vendor/github.com/inconshreveable/mousetrap"
     },
     {
-        "type": "git",
-        "url": "https://github.com/jcmturner/aescts.git",
-        "tag": "v2.0.0",
+        "type": "archive",
+        "url": "https://proxy.golang.org/github.com/jcmturner/aescts/v2/@v/v2.0.0.zip",
+        "sha256": "717a211ad4aac248cf33cadde73059c13f8e9462123a0ab2fed5c5e61f7739d7",
+        "strip-components": 4,
         "dest": "vendor/github.com/jcmturner/aescts/v2"
     },
     {
-        "type": "git",
-        "url": "https://github.com/jcmturner/dnsutils.git",
-        "tag": "v2.0.0",
-        "dest": "vendor/github.com/jcmturner/dnsutils/v2"
+        "type": "archive",
+        "url": "https://proxy.golang.org/github.com/jcmturner/dnsutils/v2/@v/v2.0.0.zip",
+        "dest": "vendor/github.com/jcmturner/dnsutils/v2",
+        "strip-components": 4,
+        "sha256": "f9188186b672e547cfaef66107aa62d65054c5d4f10d4dcd1ff157d6bf8c275d"
     },
     {
-        "type": "git",
-        "url": "https://github.com/jcmturner/gofork.git",
-        "tag": "v1.0.0",
-        "dest": "vendor/github.com/jcmturner/gofork"
+        "type": "archive",
+        "url": "https://proxy.golang.org/github.com/jcmturner/gofork/@v/v1.0.0.zip",
+        "dest": "vendor/github.com/jcmturner/gofork",
+        "strip-components": 3,
+        "sha256": "5e015dd9b038f1dded0b2ded77e529d2f6ba0bed228a98831af5a3610eefcb52"
     },
     {
-        "type": "git",
-        "url": "https://github.com/jcmturner/goidentity.git",
-        "tag": "v6.0.1",
-        "dest": "vendor/github.com/jcmturner/goidentity/v6"
+        "type": "archive",
+        "url": "https://proxy.golang.org/github.com/jcmturner/goidentity/v6/@v/v6.0.1.zip",
+        "dest": "vendor/github.com/jcmturner/goidentity/v6",
+        "strip-components": 4,
+        "sha256": "243e6fd6ea9f3094eea32c55febade6d8aaa1b563db655b0c5327940e4719beb"
     },
     {
-        "type": "git",
-        "url": "https://github.com/jcmturner/gokrb5.git",
-        "tag": "v8.4.2",
-        "dest": "vendor/github.com/jcmturner/gokrb5"
+        "type": "archive",
+        "url": "https://proxy.golang.org/github.com/jcmturner/gokrb5/v8/@v/v8.4.2.zip",
+        "dest": "vendor/github.com/jcmturner/gokrb5/v8",
+        "strip-components": 4,
+        "sha256": "eecd7120363321bb6b58b015395089958720271b3211659d802447d417af5970"
     },
     {
-        "type": "git",
-        "url": "https://github.com/jcmturner/rpc.git",
-        "tag": "v2.0.3",
-        "dest": "vendor/github.com/jcmturner/rpc"
+        "type": "archive",
+        "url": "https://proxy.golang.org/github.com/jcmturner/rpc/v2/@v/v2.0.3.zip",
+        "dest": "vendor/github.com/jcmturner/rpc/v2",
+        "strip-components": 4,
+        "sha256": "90c595355e5e2c9dc1e1ae71a88491a04c34d8791180098da103217cbf5f5574"
     },
     {
         "type": "git",
@@ -134,13 +140,13 @@
     {
         "type": "git",
         "url": "https://github.com/spf13/cobra.git",
-        "tag": "v0.0.3",
+        "tag": "v1.6.0",
         "dest": "vendor/github.com/spf13/cobra"
     },
     {
         "type": "git",
         "url": "https://github.com/spf13/pflag.git",
-        "tag": "v1.0.3",
+        "tag": "v1.0.5",
         "dest": "vendor/github.com/spf13/pflag"
     },
     {
@@ -182,25 +188,25 @@
     {
         "type": "git",
         "url": "https://go.googlesource.com/net",
-        "dest": "vendor/golang.org/x/net",
-        "commit": "69e39bad7dc2"
+        "tag": "v0.7.0",
+        "dest": "vendor/golang.org/x/net"
     },
     {
         "type": "git",
         "url": "https://go.googlesource.com/sync",
-        "dest": "vendor/golang.org/x/sync",
-        "commit": "036812b2e83c"
+        "tag": "v0.1.0",
+        "dest": "vendor/golang.org/x/sync"
     },
     {
         "type": "git",
         "url": "https://go.googlesource.com/sys",
-        "dest": "vendor/golang.org/x/sys",
-        "commit": "665e8c7367d1"
+        "tag": "v0.5.0",
+        "dest": "vendor/golang.org/x/sys"
     },
     {
         "type": "git",
         "url": "https://go.googlesource.com/text",
-        "tag": "v0.3.7",
+        "tag": "v0.7.0",
         "dest": "vendor/golang.org/x/text"
     },
     {


### PR DESCRIPTION
GO significantly changed dependency resolutions and vendoring. None of the previous methods or helper tools work in entirety.